### PR TITLE
Fixed typo on the hyperlink

### DIFF
--- a/overlay/root/www/hosted.html
+++ b/overlay/root/www/hosted.html
@@ -4,7 +4,7 @@
 	<title>Speedtest by OpenSpeedtest.com</title>
 </head>
 <body>
-<!--OST Widget code start--><div style="text-align:right;"><div style="min-height:360px;"><div style="width:100%;height:0;padding-bottom:50%;position:relative;"><iframe style="border:none;position:absolute;top:0;left:0;width:100%;height:100%;min-height:360px;border:none;overflow:hidden !important;" src="//openspeedtest.com/ost-self-hosted.php"></iframe></div></div>Provided by  <a href="http://openspeedtest.com">OpeSpeedtest.com</a></div><!-- OST Widget code end -->
+<!--OST Widget code start--><div style="text-align:right;"><div style="min-height:360px;"><div style="width:100%;height:0;padding-bottom:50%;position:relative;"><iframe style="border:none;position:absolute;top:0;left:0;width:100%;height:100%;min-height:360px;border:none;overflow:hidden !important;" src="//openspeedtest.com/ost-self-hosted.php"></iframe></div></div>Provided by  <a href="http://openspeedtest.com">OpenSpeedtest.com</a></div><!-- OST Widget code end -->
 
 </body>
 </html>


### PR DESCRIPTION
Fixed the typo, changed the text from "OpeSpeedtest.com" to "OpenSpeedtest.com"